### PR TITLE
Fix bug: Origin rounding error in saving grid file

### DIFF
--- a/xmscore/dataio/daStreamIo.cpp
+++ b/xmscore/dataio/daStreamIo.cpp
@@ -1313,7 +1313,8 @@ void daWrite3DoubleLine(std::ostream& a_outStream,
                         const double& a_val2,
                         const double& a_val3)
 {
-  a_outStream << a_name << ' ' << a_val1 << ' ' << a_val2 << ' ' << a_val3 << '\n';
+  a_outStream << a_name << ' ' << STRstd(a_val1) << ' ' << STRstd(a_val2) << ' ' << STRstd(a_val3)
+              << '\n';
 } // daWrite3DoubleLine
 //------------------------------------------------------------------------------
 /// \brief Write a named integer value to a line.
@@ -1648,11 +1649,11 @@ void DaStreamIoUnitTests::testReadWrite3DoubleLine()
 {
   std::ostringstream outputStream;
   const char* name = "LINE_NAME";
-  const double expect1 = 22.1;
-  const double expect2 = 22.2;
+  const double expect1 = 560770.5;
+  const double expect2 = 70055.4;
   const double expect3 = 22.3;
   daWrite3DoubleLine(outputStream, name, expect1, expect2, expect3);
-  std::string outputExpected = "LINE_NAME 22.1 22.2 22.3\n";
+  std::string outputExpected = "LINE_NAME 560770.5 70055.4 22.3\n";
   std::string outputFound = outputStream.str();
   TS_ASSERT_EQUALS(outputExpected, outputFound);
 

--- a/xmscore/testing/TestTools.h
+++ b/xmscore/testing/TestTools.h
@@ -13,9 +13,11 @@
 #include <vector>
 
 // 4. External library headers
-//#ifdef CXX_TEST
+#ifdef CXX_TEST
 #include <cxxtest/TestSuite.h>
-//#endif // ifdef CXX_TEST
+#else
+#error "Should only be included in builds with testing enabled."
+#endif // ifdef CXX_TEST
 
 // 5. Shared code headers
 #include <xmscore/points/ptsfwd.h>


### PR DESCRIPTION
Added more precision to the base function daWrite3DoubleLine by using STRstd.  Updated testReadWrite3DoubleLine to test the additional precision.