### PR TITLE
Use legacy wchar_t setting for MD builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,14 @@ if(WIN32)
     string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
   endif()
 
+  if(USES_MT)
+    add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
+  else()
+    add_definitions(/Zc:wchar_t-)  # Treat wchar_t as built-in type
+  endif()
+
   if(XMS_BUILD)
       add_definitions(/D _WIN32_WINNT=0x0501)  # Windows XP and higher
-      if(USES_MT)
-        add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
-      else()
-        add_definitions(/Zc:wchar_t-)  # Treat wchar_t as built-in type
-      endif()
   else(NOT XMS_BUILD)
       add_definitions(/D BOOST_ALL_NO_LIB)
   endif()

--- a/_package/xms/core/__init__.py
+++ b/_package/xms/core/__init__.py
@@ -4,4 +4,4 @@ The __init__.py for the core module of the xms.core library.
 from . import filesystem  # NOQA: F401
 from . import misc  # NOQA: F401
 
-__version__ = '4.0.1'
+__version__ = '4.0.2'

--- a/conanfile.py
+++ b/conanfile.py
@@ -198,7 +198,10 @@ class XmscoreConan(ConanFile):
 
     def requirements(self):
         """Requirements."""
-        self.requires("boost/1.74.0@aquaveo/stable")
+        if self.settings.compiler == 'Visual Studio' and 'MD' in str(self.settings.compiler.runtime):
+            self.requires("boost/1.74.0@aquaveo/testing")  # Use legacy wchar_t setting for XMS
+        else:
+            self.requires("boost/1.74.0@aquaveo/stable")
         # Pybind if not clang
         if not self.settings.compiler == "clang" and self.options.pybind:
             self.requires("pybind11/2.5.0@aquaveo/testing")


### PR DESCRIPTION
Using wchar_t as a built-in type causes link errors when building with XMS. Use the boost built with legacy wchar_t flag for these configurations.