### PR TITLE
Fix handling if 8.3 filenames in is_somewhere_below_system_temp

### DIFF
--- a/_package/xms/core/filesystem/filesystem.py
+++ b/_package/xms/core/filesystem/filesystem.py
@@ -159,7 +159,7 @@ def is_somewhere_below_system_temp(filename: str | Path) -> bool:
     Returns:
         See description.
     """
-    temp_dir = Path(tempfile.gettempdir())
+    temp_dir = Path(tempfile.gettempdir()).resolve()
     filepath = Path(filename)
     return temp_dir in filepath.parents
 


### PR DESCRIPTION
Fix a case where is_somewhere_below_system_temp would yield incorrect results for Windows users with long names.