### PR TITLE
Bump xmsconan to 2.12.1 and add Windows Python 3.10 build

### DIFF
--- a/.github/workflows/XmsCore-CI.yaml
+++ b/.github/workflows/XmsCore-CI.yaml
@@ -82,6 +82,7 @@ jobs:
       # Python Variables
       PYTHON_TARGET_VERSION: ${{ matrix.python-version }}
       RELEASE_PYTHON: 'False'
+      CTEST_PARALLEL_LEVEL: '8'
 
     steps:
       # Get Correct Version of Xcode
@@ -95,16 +96,16 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.8.1 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.12.1 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -228,6 +229,7 @@ jobs:
       # Python Variables
       PYTHON_TARGET_VERSION: '3.13'
       RELEASE_PYTHON: 'False'
+      CTEST_PARALLEL_LEVEL: '8'
 
     steps:
       # Checkout Sources
@@ -237,7 +239,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan devpi-client wheel
-          pip install xmsconan>=2.8.1 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install xmsconan>=2.12.1 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -336,12 +338,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
-        python-version: ['3.13']
+        python-version: ["3.10", "3.13"]
         compiler-version: [17]
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
+      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmscore
       XMS_VERSION: '0.0.0'
@@ -361,16 +363,17 @@ jobs:
       # Python Variables
       PYTHON_TARGET_VERSION: ${{ matrix.python-version }}
       RELEASE_PYTHON: 'False'
+      CTEST_PARALLEL_LEVEL: '8'
 
     steps:
       # Checkout Sources
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Setup Dev Command Prompt env for MSVC
       - name: Setup MSVC env
         uses: ilammy/msvc-dev-cmd@v1
@@ -381,7 +384,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.8.1 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.12.1 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2
@@ -435,7 +438,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi

--- a/build.toml
+++ b/build.toml
@@ -6,6 +6,9 @@ xms_dependencies = []
 python_namespaced_dir = "core"
 pybind_root = true
 
+[ci]
+python_versions = ["3.10", "3.13"]
+
 library_sources = [
     "xmscore/dataio/daStreamIo.cpp",
     "xmscore/math/math.cpp",

--- a/build.toml
+++ b/build.toml
@@ -6,9 +6,6 @@ xms_dependencies = []
 python_namespaced_dir = "core"
 pybind_root = true
 
-[ci]
-python_versions = ["3.10", "3.13"]
-
 library_sources = [
     "xmscore/dataio/daStreamIo.cpp",
     "xmscore/math/math.cpp",
@@ -104,3 +101,6 @@ pybind_headers = [
     "xmscore/python/misc/PyProgressListener.h",
     "xmscore/python/time/time_py.h",
 ]
+
+[ci]
+python_versions = ["3.10", "3.13"]


### PR DESCRIPTION
## Summary
- Bumps the CI's xmsconan requirement to 2.12.1, picking up the Windows cxxtestgen path fix (xmsconan #50) that was breaking master builds.
- Adds `[ci] python_versions = ["3.10", "3.13"]` to `build.toml` so the Windows matrix builds wheels for both Python versions; macOS/Linux remain on 3.13 (multi-Python is Windows-only in xmsconan today — see xmsconan #49 for docs).
- `XmsCore-CI.yaml` regenerated by `xmsconan_ci`; CTest now runs with `CTEST_PARALLEL_LEVEL=8` and Python-version-aware matrix names and wheel artifact names from upstream.

## Test plan
- [ ] CI is green on all platforms
- [ ] Windows runs build both 3.10 and 3.13 wheel artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)