### PR TITLE
Regenerate CI workflows with xmsconan 2.15.3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,7 @@ exclude =
     __pycache__,
     _package/tests/files/*,
     docs/source/conf.py,
+    pydocs/source/conf.py,
     build,
     dist,
     tests/files/*,
@@ -17,7 +18,6 @@ exclude =
 ignore = D200, D212, B028, W503
 max-line-length = 120
 docstring-convention = google
-isolated = true
 import-order-style = appnexus
 application-import-names = xms.core
 application-package-names = xms

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan wheel "gcovr>=7,<9"
-          pip install --upgrade "xmsconan>=2.15.2" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
 
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login

--- a/.github/workflows/XmsCore-CI.yaml
+++ b/.github/workflows/XmsCore-CI.yaml
@@ -42,10 +42,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
+          pip install "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+      # Generate .flake8 so CI lints with the same config developers use locally.
+      # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
+      # the two copies drift apart silently.
+      - name: Generate Build Files
+        run: xmsconan_gen build.toml
       # Flake Code
       - name: Run Flake
-        run: |
-          flake8 --exclude .tox,.git,__pycache__,_package/tests/files/*,pydocs/source/conf.py,build,dist,tests/fixtures/*,*.pyc,*.egg-info,.cache,.eggs --ignore=D200,D212 --max-line-length=120 --docstring-convention google --isolated --import-order-style=appnexus --application-import-names=xms.core --application-package-names=xms --count --statistics _package
+        run: flake8 _package
 
   # ----------------------------------------------------------------------------------------------
   # MAC
@@ -104,8 +109,11 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install conan devpi-client wheel
-          python -m pip install --upgrade "xmsconan>=2.15.2" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          # conan is pinned to a patch series on purpose: a minor bump can change
+          # package_id computation and silently detach builds from the binaries
+          # already published to the remote. Bump this deliberately.
+          pip install "conan~=2.31.0" devpi-client wheel
+          python -m pip install --upgrade "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -238,8 +246,11 @@ jobs:
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
-          pip install conan devpi-client wheel
-          pip install --upgrade "xmsconan>=2.15.2" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          # conan is pinned to a patch series on purpose: a minor bump can change
+          # package_id computation and silently detach builds from the binaries
+          # already published to the remote. Bump this deliberately.
+          pip install "conan~=2.31.0" devpi-client wheel
+          pip install --upgrade "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -383,8 +394,11 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install conan devpi-client wheel
-          python -m pip install --upgrade "xmsconan>=2.15.2" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          # conan is pinned to a patch series on purpose: a minor bump can change
+          # package_id computation and silently detach builds from the binaries
+          # already published to the remote. Bump this deliberately.
+          pip install "conan~=2.31.0" devpi-client wheel
+          python -m pip install --upgrade "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
Regenerates CI and build files with xmsconan 2.15.3 (was 2.15.2).

- `XmsCore-CI.yaml`: flake job now installs xmsconan, runs `xmsconan_gen build.toml` to render `.flake8`, and runs plain `flake8 _package` — the inline flake8 arguments are gone, so `.flake8` is the single lint source of truth.
- Build/deploy steps pin `xmsconan==2.15.3` (was `>=`) and `conan~=2.31.0` (was unpinned).
- `Coverage.yaml` intentionally keeps `xmsconan>=`.
- `.flake8`: adds `pydocs/source/conf.py` to exclude, drops `isolated = true`.

CMakeLists.txt is unchanged — xmscore was already on 2.15.2, which carried the `source_group`/`IS_EMSCRIPTEN_BUILD` changes.

Release notes: https://github.com/Aquaveo/xmsconan/releases/tag/2.15.3