### PR TITLE
Regenerate CI workflows with xmsconan 2.15.5

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python 3.13
         uses: actions/setup-python@v5
@@ -45,7 +45,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan wheel "gcovr>=7,<9"
-          pip install --upgrade "xmsconan>=2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
 
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login

--- a/.github/workflows/XmsCore-CI.yaml
+++ b/.github/workflows/XmsCore-CI.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -99,7 +99,7 @@ jobs:
           clang --version
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -242,7 +242,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
@@ -250,7 +250,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -379,7 +379,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.15.3" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
Regenerates CI files with xmsconan 2.15.5 (was 2.15.3), bringing xmscore in line with the rest of the suite.

## Changes

- `actions/checkout@v2` → `@v4` (5 occurrences: 4 in `XmsCore-CI.yaml`, 1 in `Coverage.yaml`). v2 is deprecated — GitHub already force-runs its Node 20 actions on Node 24 and warns on v2.
- `xmsconan==2.15.3` → `==2.15.5` in every build/deploy/lint step.
- `Coverage.yaml` moves `xmsconan>=2.15.3` → `>=2.15.5`, deliberately keeping `>=` as the canary.

`.flake8` is unchanged — nothing in it moved between 2.15.3 and 2.15.5.

## Why now

xmscore shipped 7.0.9 before two template bugs were found and fixed upstream:

- **xmsconan#81 / 2.15.4** — the templates emitted `checkout@v2`, so regeneration reverted repos that had moved to v4.
- **xmsconan#82 / 2.15.5** — the GitLab template emitted an `undefined need` that produced job-less pipelines (GitHub-only repos like this one were unaffected).

This picks up both, so xmscore is no longer the one repo on the pre-fix template.

## Verification

```
flake8 --extend-ignore=AQU _package -> exit 0
```

AQU codes are excluded because the GitHub flake job does not install flake8-aquaveo — that plugin is published only to the internal index (`aquapi.aquaveo.com`, which resolves to 192.168.99.1 and is unreachable from GitHub-hosted runners), so this matches what CI actually runs.

To be released as **7.0.10**.