### PR TITLE
Regenerate CI workflows with xmsconan 2.16.0

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan wheel "gcovr>=7,<9"
-          pip install --upgrade "xmsconan>=2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
 
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login

--- a/.github/workflows/XmsCore-CI.yaml
+++ b/.github/workflows/XmsCore-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -250,7 +250,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.15.5" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
Bumps the xmsconan pin to 2.16.0 (was 2.15.5).

## Why this matters more than the diff suggests

The tracked change is five pin lines, but the effect is on the **published artifact**. xmsconan 2.16.0 compiles `testing_sources` into the library again, so a build produced under this pin publishes xmscore's testing helpers — `ttEqualPointsXYZ`, `ttTextFilesEqual` and friends — for dependent libraries to link.

`CMakeLists.txt` is generated at build time by the `Generate Build Files` step and is not tracked in this repo, so the pin is the entire change here. Regenerating locally with 2.16.0 confirms the rendered file now contains:

```cmake
if (NOT IS_PYTHON_BUILD)
    list(APPEND xmscore_sources ${xmscore_testing_sources})
endif ()
```

`Coverage.yaml` moves to `xmsconan>=2.16.0`, keeping `>=` as the canary.

## Context

xmscore 7.0.8 (2026-05-06) is the last release whose library carries the testing helpers — xmsconan 2.15.1 moved them into the runner target eight days later. 7.0.9 and 7.0.10 were therefore built without them, and downstream libraries fail to link against those builds:

```
undefined reference to `xms::ttTextFilesEqual(...)'
```

71 files across six repos depend on those symbols. This is the first half of the fix; the second is releasing xmscore so a package built under 2.16.0 actually exists on the remote.

## Verification

```
flake8 --extend-ignore=AQU _package -> exit 0
```

The real verification is CI itself — particularly the Coverage workflow, which exercises the two-build split (`testing=True+pybind=False` and `testing=False+pybind=True`) that this change depends on for its safety argument.

To be released as **7.0.11**, after which xmsgrid can re-point at it and the cascade can resume.