### PR TITLE
Regenerate CI workflows with xmsconan 2.18.0

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan wheel "gcovr>=7,<9"
-          pip install --upgrade "xmsconan>=2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
 
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login

--- a/.github/workflows/XmsCore-CI.yaml
+++ b/.github/workflows/XmsCore-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -250,7 +250,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
Bumps generated CI onto xmsconan 2.18.0 ([The VS2019 Bridge Release](https://github.com/Aquaveo/xmsconan/releases/tag/2.18.0)). Five lines, all pins.

## Why this is required, not housekeeping

`XmsConan2File.export()` copies `xms_conan2_file.py` into the export folder, so its contents feed the **recipe revision hash**. 2.18.0 changes that file by 192 lines — the msvc 192 fork (`_is_vs2019`, `vs2019_requirements`, `vs2019_dependency_overrides`).

That means a `7.0.x` built by CI on the `2.16.0` pin and the same `7.0.x` built locally for VS2019 on 2.18.0 export **different recipes** and resolve to **different rrevs**. `aquaveo-stable` and `aquaveo-vs2019` would be silently out of step on a version that reads as one release — precisely the failure the VS2019 bridge exists to avoid. Both sides have to generate from the same xmsconan.

## Blast radius on the VS2022 side: none

Diffed the generated output against a real `xmsconan==2.16.0` install (not the editable one):

| File | 2.16.0 vs 2.18.0 |
|---|---|
| `conanfile.py` | identical |
| `CMakeLists.txt` | identical |
| `pytest.ini` | identical |
| `build.py` | `exit 1` when `builder.upload()` reports errors, instead of failing silently. Not exported. |
| `xms_conan2_file.py` | 192 lines — the vs2019 fork. This is the intended rrev move. |

`conanfile.py` gains a `vs2019_dependency_overrides` attribute only when `build.toml` declares that table; this repo doesn't, so it regenerates byte-identical.

On any toolchain that is not msvc 192 the dependency graph is unchanged. 2.18.0 refactored the inline `self.requires("boost/1.86.0")` / `self.requires("zlib/1.3.1")` calls into an iteration over `default_requirements`, which holds those same two references in the same order.

## This should be the last regeneration commit

2.17.0 floated generated CI from `==` onto `>=` with `--upgrade`, so a future xmsconan reaches CI on its next run rather than waiting on a regenerate-and-commit pass. The flake job picks up `--upgrade` here, which it lacked under the `==` pin.

Note `Coverage.yaml` was already floating (`>=2.16.0`); only its floor moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)