### PR TITLE
Add Python 3.14 to the CI matrix

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan wheel "gcovr>=7,<9"
-          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
 
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login

--- a/.github/workflows/XmsCore-CI.yaml
+++ b/.github/workflows/XmsCore-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -63,11 +63,11 @@ jobs:
       fail-fast: false
       matrix:
         platform: [macos-15]
-        python-version: ['3.13']
+        python-version: ["3.13", "3.14"]
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-Clang${{ matrix.compiler-version }}-${{ matrix.build_type }}
+      MATRIX_NAME: ${{ matrix.platform }}-Clang${{ matrix.compiler-version }}-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmscore
       XMS_VERSION: '0.0.0'
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -164,7 +164,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi
@@ -205,19 +205,20 @@ jobs:
   # LINUX
   # ----------------------------------------------------------------------------------------------
   linux:
-    name: GCC-13 (${{ matrix.build_type }}, Linux)
+    name: GCC-13 (${{ matrix.build_type }}, ${{ matrix.python-version }}, Linux)
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/aquaveo/conan-gcc13-py3.13:latest
+      image: ghcr.io/aquaveo/conan-gcc13-py${{ matrix.python-version }}:latest
 
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
+        python-version: ["3.13", "3.14"]
 
     env:
-      MATRIX_NAME: linux-GCC13-${{ matrix.build_type }}
+      MATRIX_NAME: linux-GCC13-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmscore
       XMS_VERSION: '0.0.0'
@@ -235,7 +236,7 @@ jobs:
       AQUAPI_PASSWORD: ${{ secrets.AQUAPI_PASSWORD_SECRET }}
       AQUAPI_URL: ${{ secrets.AQUAPI_URL_DEV }}
       # Python Variables
-      PYTHON_TARGET_VERSION: '3.13'
+      PYTHON_TARGET_VERSION: ${{ matrix.python-version }}
       RELEASE_PYTHON: 'False'
       CTEST_PARALLEL_LEVEL: '8'
 
@@ -250,7 +251,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -301,7 +302,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi
@@ -349,7 +350,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.13", "3.14"]
         compiler-version: [17]
         build_type: [Release, Debug]
 
@@ -398,7 +399,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/build.toml
+++ b/build.toml
@@ -103,9 +103,16 @@ pybind_headers = [
 ]
 
 [ci]
-python_versions = ["3.10", "3.13"]
+python_versions = ["3.10", "3.13", "3.14"]
+mac_python_versions = ["3.13", "3.14"]
+linux_python_versions = ["3.13", "3.14"]
 coverage = true
 
 [coverage]
+# Pinned so adding 3.14 to the build matrix does not also move the coverage
+# gate. Coverage otherwise follows the highest [ci].linux_python_versions
+# entry, which would have shifted it 3.13 -> 3.14 as a side effect of this
+# change. Revisit once 3.14 is proven across the suite.
+python_version = "3.13"
 cpp_threshold = 0
 python_threshold = 0


### PR DESCRIPTION
First consumer of the per-platform Python fan-out from xmsconan #96, released as 2.21.0. xmscore is the pattern repo; the other seven follow once this is green.

## The change

`build.toml` only:

```toml
[ci]
python_versions       = ["3.10", "3.13", "3.14"]   # Windows
mac_python_versions   = ["3.13", "3.14"]
linux_python_versions = ["3.13", "3.14"]

[coverage]
python_version = "3.13"
```

Workflows regenerated with `xmsconan_ci` at 2.21.0. Everything else in the diff is generated output.

Three lists rather than one because the constraints differ per platform: 3.10 exists for the desktop products' Windows wheel and nothing else needs it, and every Linux entry requires a published `conan-gcc13-py<version>` container — which exists for 3.13 and 3.14 only, with no 3.10/3.11/3.12 image on either registry.

## Verified before opting Linux in

`ghcr.io/aquaveo/conan-gcc13-py3.14` is public and anonymously pullable, which matters because the generated `container:` block carries no `credentials:` stanza. And it really is 3.14, checked by running it rather than reading its metadata:

```
$ docker run --rm ghcr.io/aquaveo/conan-gcc13-py3.14 python --version
Python 3.14.7
```

manylinux_2_28 base, gcc-toolset-13, built alongside the 3.13 image.

## Two consequences worth knowing before merge

**Release asset and wheel-artifact names change on mac and Linux.** They now carry `-py<version>` — `linux-GCC13-Release-py3.13.tar.gz` rather than `linux-GCC13-Release.tar.gz`. Unavoidable: those platforms now produce two ABIs each and the old names would have one leg overwrite the other. Windows already worked this way. If anything fetches those assets by exact name, it needs updating.

**A tagged release publishes seven wheels instead of four** — 3.10/3.13/3.14 on Windows, 3.13/3.14 on macOS and Linux. Distinct `cp3XY` tags, so they coexist under one devpi release rather than colliding. Wheel upload stays gated on `refs/tags/` plus `build_type == 'Release'`, so ordinary pushes and PRs still publish nothing.

CI time and Conan storage roughly double. If that's not wanted yet, dropping the two `*_python_versions` lines makes 3.14 Windows-only and is a one-line follow-up to widen later.

## Why coverage is pinned

Coverage resolves to the highest `linux_python_versions` entry, so leaving it default would have moved the coverage gate 3.13 → 3.14 as a side effect of a matrix change. Pinning to 3.13 keeps `Coverage.yaml`'s only diff the xmsconan version bump, so a 3.14 problem surfaces in the build legs alone rather than in two places at once. Worth removing once 3.14 is proven across the suite.

## The actual risk

**This is the first time anything in the suite compiles against 3.14.** The Conan option permits it and pybind11 is at 3.0.1, which supports 3.14, but no build has happened. Python 3.14 removed C-API entry points, and xmscore has hand-written pybind glue — `python/misc/PyUtils.cpp`, the `Listener` / `PublicProgressListener` shims. If any of it touches a removed API, this CI run is where we find out, which is the point of doing xmscore first.

Note the `linux` job's status-check name changes (`GCC-13 (Release, Linux)` → `GCC-13 (Release, 3.13, Linux)`) because the legs now differ by ABI and GitHub uses an explicit `name:` verbatim. `master` has no `required_status_checks` configured — only a one-approval review requirement — so nothing is blocked by the rename. Worth re-checking per repo as the rollout proceeds.
